### PR TITLE
Use RiffRaff Lambda lookup by tags

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -2,14 +2,11 @@ stacks:
 - ophan
 deployments:
   geoip-db-refresher:
+    type: aws-lambda
     parameters:
       bucket: ophan-dist
       fileName: geoip-db-refresher.jar
-      functions:
-        PROD:
-          filename: geoip-db-refresher.jar
-          name: Ophan-GeoIP-DB-Refresher-Lambda-16GC5O4SZ7XJ5
-    type: aws-lambda
+      lookupByTags: true
   cloudformation:
     type: cloud-formation
     app: geoip-db-refresher


### PR DESCRIPTION
https://riffraff.gutools.co.uk/docs/magenta-lib/types#awslambda says:

> lookupByTags - When true, this will lookup the function to deploy to by using the Stack, Stage and App tags on a function. The values looked up come from the&nbsp;stacks&nbsp;and&nbsp;app&nbsp;in the riff-raff.yaml and the stage deployed to.




...avoids having the noisy cloudformation-generated name in the `riff-raff.yaml`.

Used this as an example:
https://github.com/guardian/dns-validation-lambda/blob/77d820a82a12587ea35a54e88171474a8e281574/riff-raff.yaml#L11
