### PR TITLE
Grant deployTools AWS account `read` access to GeoIP DB in S3 for tests

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -31,7 +31,7 @@ Resources:
           PolicyDocument:
             Statement:
             - Effect: Allow
-              Action: s3:PutObject
+              Action: [s3:PutObject, s3:PutObjectAcl]
               Resource: arn:aws:s3:::ophan-dist/geoip/*
             - Effect: Allow
               Action: ssm:GetParameter

--- a/src/main/scala/ophan/geoip/db/refresher/MaxmindDatabaseEdition.scala
+++ b/src/main/scala/ophan/geoip/db/refresher/MaxmindDatabaseEdition.scala
@@ -44,7 +44,8 @@ object MaxmindDatabaseEdition {
   val licenceKey: String = AWS.SSM.getParameter(_.withDecryption(true).name("/Ophan/GeoIP")).parameter.value
 
   val GeoIP2City = MaxmindDatabaseEdition("GeoIP2-City", "tar.gz", "mmdb")
-
+  val GeoIP2Country = MaxmindDatabaseEdition("GeoIP2-Country", "tar.gz", "mmdb") // smaller file useful for test runs
+  
   def uriFor(editionId: String, suffix: String): URI =
     new URI(s"https://download.maxmind.com/app/geoip_download?edition_id=$editionId&license_key=$licenceKey&suffix=$suffix")
 }


### PR DESCRIPTION
As discussed in https://github.com/guardian/deploy-tools-platform/pull/456, we need TeamCity to have AWS permissions to read the GeoIP database file so it can execute our tests (ie [`GeoIPLookupTest`](https://github.com/guardian/ophan/blob/b63d7d93b/the-slab/test/lib/GeoIPLookupTest.scala) ).

Setting a bucket-wide policy gets clobbered by the S3 bucket-policy enforcer process run by Data Tech, but specifically uploading the file itself with the right permissions should hopefully be more durable. The [resulting permissions on the S3 object](https://s3.console.aws.amazon.com/s3/object/ophan-dist?region=eu-west-1&prefix=geoip%2FGeoIP2-City.mmdb&tab=permissions) look like this:

![image](https://user-images.githubusercontent.com/52038/119010209-b993dc80-b98b-11eb-976f-d2fb034f096c.png)

...that external account is the Deploy Tools AWS account. It seems to be easiest with S3 to [grant read](url) permissions to the whole Deploy Tools AWS Account, and then for https://github.com/guardian/deploy-tools-platform/pull/456 to grant access to just specifically TeamCity agents.

The S3 docs say:

> You specify each grantee as a type=value pair, where the type is one of the following:
> * id – if the value specified is the canonical user ID of an AWS account
> * uri – if you are granting permissions to a [predefined group](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#specifying-grantee-predefined-groups)
> * emailAddress – if the value specified is the email address of an AWS account

We've chosen to use the first option - granting access to the specific AWS account - as it seems to be the only one useful to us.

I've test [deployed](https://riffraff.gutools.co.uk/deployment/view/5db7384a-4604-43c3-9f70-3cd94894c4c6) the Lambda with these changes, run the lambda, which [successfully uploaded the file](https://logs.gutools.co.uk/s/ophan/goto/f1382a3cb947e747964e6665f61672c1) - and TeamCity boxes (eg `i-0d29515b7e29ccff4`) _can_ download the file if I `ssm` to the machine:

```
$ ssm cmd --profile deployTools  -i i-0d29515b7e29ccff4 -c "aws s3 cp s3://ophan-dist/geoip/GeoIP2-City.mmdb /tmp/"
========= i-0d29515b7e29ccff4 =========
STDOUT:
Completed 88.5 MiB/119.8 MiB (193.7 MiB/s) with 1 file(s) rem--output truncated--
STDERR:
```

...to get the actual Ophan Tests to pass though, we need the tests to stop using anonymous S3 access! PR https://github.com/guardian/ophan/pull/4153 does that.