### PR TITLE
Add scheduled rule to kick off the refresh weekly

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -52,3 +52,20 @@ Resources:
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java11
       Timeout: 120
+
+  ScheduledRule:
+    Type: AWS::Events::Rule
+    Properties:
+      ScheduleExpression: cron(20 11 ? * WED *) # MaxMind: "Weekly updates are available every Tuesday"
+      Targets:
+      - Arn: !GetAtt [Lambda, Arn]
+        Id: GeoIPRefresherLambda
+
+  # Permission to allow the event rule to trigger the lambda
+  InvokeLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref Lambda
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt [ScheduledRule, Arn]


### PR DESCRIPTION
MaxMind [say](https://support.maxmind.com/geoip-faq/databases-and-database-updates/how-often-are-the-geoip2-and-geoip-legacy-databases-updated/) _"Weekly updates are available every Tuesday"_ - so I guess we should grab a fresh copy of the GeoIP database once a week, on Wednesday!

This change adds a cloud-formed [AWS Event Rule](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html) to trigger the lambda on a weekly basis.



