### PR TITLE
Update refresher to run twice a week

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -56,7 +56,7 @@ Resources:
   ScheduledRule:
     Type: AWS::Events::Rule
     Properties:
-      ScheduleExpression: cron(20 11 ? * WED *) # MaxMind: "Weekly updates are available every Tuesday"
+      ScheduleExpression: cron(20 11 ? * WED,SAT *) # MaxMind: "Databases updated twice weekly on Tuesdays and Fridays"
       Targets:
       - Arn: !GetAtt [Lambda, Arn]
         Id: GeoIPRefresherLambda


### PR DESCRIPTION
MaxMind recently sent out [an email](https://groups.google.com/a/guardian.co.uk/g/ophan.dev/c/KNHsnZYp1PM/m/KO_12_tNEAAJ) saying their databases are now being updated twice a week rather than one. 

This commit updates the refresher to run twice a week so we're as up to date as possible. [Before](https://github.com/guardian/ophan-geoip-db-refresher/pull/3), MaxMind updated once a week on Tuesdays, so we refreshed on Wednesdays. The new second update is on Fridays, so the cron expression has been updated to run on Saturdays too.

This addresses https://github.com/guardian/ophan/issues/4199.
