### PR TITLE
Increase memory to avoid OOM errors during download

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -48,7 +48,7 @@ Resources:
         S3Key: ophan/PROD/geoip-db-refresher/geoip-db-refresher.jar
       Description: Fetching the latest GeoIP database and putting it in S3 for Ophan
       Handler: ophan.geoip.db.refresher.Lambda::handler
-      MemorySize: 512
+      MemorySize: 1024
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java11
       Timeout: 120


### PR DESCRIPTION
The GeoIp file has grown _slightly_ larger (from 134368384 to 134801401 bytes) - and now we're seeing consistent OutOfMemoryErrors?!

Memory usage as reported at the end of an unsuccessful run with 512MB:

> REPORT RequestId: 8f4b33f4-8913-4095-9bfa-3b1f64fd1e6a	Duration: 38466.58 ms	Billed Duration: 38467 ms	Memory Size: 512 MB	Max Memory Used: 395 MB

We increased memory size to 1024MB, and the function ran successfully:

> REPORT RequestId: b4a76e3b-581d-4296-a613-0ca50ec92e2f	Duration: 19931.72 ms	Billed Duration: 19932 ms	Memory Size: 1024 MB	Max Memory Used: 750 MB	Init Duration: 416.56 ms

...this would indicate, for the time being at least, we need a minimum of 750 MB for this lambda. It's surprisingly inefficent given the streaming code involved though 😢

```
Java heap space: java.lang.OutOfMemoryError
java.lang.OutOfMemoryError: Java heap space
	at java.base/java.util.Arrays.copyOf(Unknown Source)
	at java.base/java.io.ByteArrayOutputStream.grow(Unknown Source)
	at java.base/java.io.ByteArrayOutputStream.ensureCapacity(Unknown Source)
	at java.base/java.io.ByteArrayOutputStream.write(Unknown Source)
	at java.base/sun.net.www.http.PosterOutputStream.write(Unknown Source)
	at software.amazon.awssdk.utils.IoUtils.copy(IoUtils.java:113)
	at software.amazon.awssdk.utils.IoUtils.copy(IoUtils.java:99)
	at software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient$RequestCallable.lambda$null$0(UrlConnectionHttpClient.java:208)
	at software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient$RequestCallable$$Lambda$437/0x000000084036d840.get(Unknown Source)
	at software.amazon.awssdk.utils.FunctionalUtils.lambda$safeSupplier$4(FunctionalUtils.java:108)
	at software.amazon.awssdk.utils.FunctionalUtils$$Lambda$77/0x000000084016e840.get(Unknown Source)
	at software.amazon.awssdk.utils.FunctionalUtils.invokeSafely(FunctionalUtils.java:136)
	at software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient$RequestCallable.lambda$call$1(UrlConnectionHttpClient.java:208)
	at software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient$RequestCallable$$Lambda$436/0x000000084036e440.accept(Unknown Source)
	at java.base/java.util.Optional.ifPresent(Unknown Source)
	at software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient$RequestCallable.call(UrlConnectionHttpClient.java:207)
	at software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient$RequestCallable.call(UrlConnectionHttpClient.java:193)
	at software.amazon.awssdk.core.internal.util.MetricUtils.measureDurationUnsafe(MetricUtils.java:64)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.MakeHttpRequestStage.executeHttpRequest(MakeHttpRequestStage.java:76)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.MakeHttpRequestStage.execute(MakeHttpRequestStage.java:55)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.MakeHttpRequestStage.execute(MakeHttpRequestStage.java:39)
	at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
	at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
	at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
	at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:73)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:42)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:78)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:40)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptMetricCollectionStage.execute(ApiCallAttemptMetricCollectionStage.java:50)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptMetricCollectionStage.execute(ApiCallAttemptMetricCollectionStage.java:36)
	at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:64)
```

This was causing [builds to fail](https://teamcity.gutools.co.uk/buildConfiguration/Ophan_OphanAll/707154), but increasing the memory in the Lambda console has fixed the issue:

![image](https://user-images.githubusercontent.com/23078809/141111008-166bfcd8-9f4b-4efd-bf92-976386196656.png)

The [Cloudformation stack](https://eu-west-1.console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/template?stackId=arn%3Aaws%3Acloudformation%3Aeu-west-1%3A021353022223%3Astack%2FOphan-GeoIP-DB-Refresher%2Fdbb06dc0-a44a-11eb-bc07-06d80796af69&filteringStatus=active&filteringText=&viewNested=true&hideStacks=false) has been updated to reflect this new value too: 

![image](https://user-images.githubusercontent.com/23078809/141111189-e3feb9b2-a973-4db5-b06e-95a18ffffb6c.png)


Closes https://github.com/guardian/ophan-geoip-db-refresher/issues/7
