### PR TITLE
Improve memory usage with streaming of AWS requests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ libraryDependencies ++= Seq(
   "org.apache.commons" % "commons-compress" % "1.21",
   "commons-io" % "commons-io" % "2.11.0",
 
-) ++ Seq("ssm", "s3", "url-connection-client").map(artifact => "software.amazon.awssdk" % artifact % "2.17.85")
+) ++ Seq("ssm", "s3", "url-connection-client").map(artifact => "software.amazon.awssdk" % artifact % "2.17.97")
 
 enablePlugins(RiffRaffArtifact, BuildInfoPlugin)
 


### PR DESCRIPTION
AWS SDK v2.17.97 includes https://github.com/aws/aws-sdk-java-v2/pull/2848, which lowers memory consumption by streaming request data, rather than loading the entire request into memory before sending it, which can make a large difference to consumption of memory when uploading large files to S3.

In the case of the `geoip-db-refresher`, it's actually economical to run with _more_ RAM than we need (we're billed for fewer GB-seconds when specifying a `MemorySize` of 1536MB than 1024MB, as AWS Lambdas are given more CPU to match increased memory) so this is no longer a serious issue for the 134MB file uploaded here!

See also:

* https://github.com/guardian/ophan-geoip-db-refresher/issues/7
* https://github.com/guardian/ophan-geoip-db-refresher/pull/8
* https://github.com/guardian/ophan-geoip-db-refresher/commit/1de50ef58cfbfd0e606083a87b01df461f0d1194
* https://aws.amazon.com/lambda/pricing/
* https://docs.aws.amazon.com/lambda/latest/dg/configuration-function-common.html#configuration-memory-console
