### PR TITLE
Upgrade to sbt v1.5.6 for Log4J2 RCE (`CVE-2021-44228`)

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.5.6


### PR DESCRIPTION
sbt is the only part of this project using Log4J - the implementation of `ophan-housekeeper` has been verified to not depend on Log4J using `sbt dependencyTree`.

See also:

* https://www.lunasec.io/docs/blog/log4j-zero-day
* https://github.com/advisories/GHSA-jfh8-c2jp-5v3q