### PR TITLE
Upgrade to sbt v1.5.7 and compact buildinfo setting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import com.gu.riffraff.artifact.BuildInfo
+
 name := "geoip-db-refresher"
 
 organization := "com.gu"
@@ -42,11 +44,11 @@ assembly / assemblyMergeStrategy := {
 
 
 buildInfoPackage := "ophan.geoip.extractor"
-buildInfoKeys := Seq[BuildInfoKey](
-  "buildNumber" -> Option(System.getenv("BUILD_NUMBER")).getOrElse("DEV"),
-  // so this next one is constant to avoid it always recompiling on dev machines.
-  // we only really care about build time on teamcity, when a constant based on when
-  // it was loaded is just fine
-  "buildTime" -> System.currentTimeMillis,
-  "gitCommitId"-> Option(System.getenv("BUILD_VCS_NUMBER")).getOrElse("DEV")
-)
+buildInfoKeys := {
+  lazy val buildInfo = BuildInfo(baseDirectory.value)
+  Seq[BuildInfoKey](
+    "buildNumber" -> buildInfo.buildIdentifier,
+    "gitCommitId" -> buildInfo.revision,
+    "buildTime" -> System.currentTimeMillis
+  )
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.6
+sbt.version=1.5.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.0")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.12")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")


### PR DESCRIPTION
https://github.com/sbt/sbt/releases/tag/v1.5.7 updates log4j 2 to 2.16.0, which disables JNDI lookup and fixes a denial of service vulnerability (CVE-2021-45046).

I've also stuck as small tweak to the buildinfo settings in, taking advantage of https://github.com/guardian/sbt-riffraff-artifact/pull/33 .