### PR TITLE
Run more often: catch late releases of MaxMind data

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -58,7 +58,8 @@ Resources:
   ScheduledRule:
     Type: AWS::Events::Rule
     Properties:
-      ScheduleExpression: cron(20 11 ? * WED,SAT *) # MaxMind: "Databases updated twice weekly on Tuesdays and Fridays"
+      # MaxMind: "Databases updated twice weekly on Tuesdays and Fridays" ... can be "delayed by about one day"
+      ScheduleExpression: cron(20 11 ? * WED,THU,SAT,SUN *)
       Targets:
       - Arn: !GetAtt [Lambda, Arn]
         Id: GeoIPRefresherLambda


### PR DESCRIPTION
We have [code in the main Ophan build](https://github.com/guardian/ophan/blob/88418434b3939a4f4452aa795c0a4766fa252e2a/the-slab/test/lib/GeoIPLookupTest.scala#L22-L26) that checks whether the current geo-ip data in S3 is current (less than 9 days old). This would alert us if the `ophan-geoip-db-refresher` lambda was silently failing, but it is now also alerting us (and failing the build) when MaxMind don't release updates to their regular Tuesday-&-Friday schedule (sometimes, eg for holidays, releases can be delayed).

Here's an example Ophan CI build failure on Friday 25th February 2022:

```
sbt.ForkMain$ForkError: org.scalatest.exceptions.TestFailedException: The MaxMind database is dated 2022-02-16T17:10:50Z, which is more than 9 days old. The lambda should have given us a more recent version?!
```

The lambda has just been running on Wednesday and Saturdays (to catch the Tuesday-&-Friday releases):

https://github.com/guardian/ophan-geoip-db-refresher/blob/e2842eddf0a3d24dd445cfb6dd7288e3dd76bbf8/cfn.yaml#L61

...and so _did_ run on Wednesday 23rd February, but all that was available at that point from MaxMind was `GeoIP2-City_20220218.tar.gz` (a file that was 5 days old - and according to that log message, contained data that was over a day old even then: `2022-02-16T17:10:50Z`!).

MaxMind say on their website (https://support.maxmind.com/hc/en-us/articles/4408216129947-Download-and-Update-Databases) that updates are released on Tuesday & Friday, but acknowledge that sometimes updates are delayed - their [service status page](https://status.maxmind.com/pages/history/53fcfbb2ac0c957972000235) highlights that the data would be late for 22nd February 2022:

> Due to the holidays on Monday, February 21, database updates scheduled for
> Tuesday, February 22 will be delayed by about one day.

![image](https://user-images.githubusercontent.com/52038/156355484-4368bf7d-2646-48a9-bcd4-cecaa692384b.png)

The `ophan-geoip-db-refresher` lambda execution that ran on Wednesday must have not been quite late enough to catch that update.

This change adds additional runs on Thursday & Sunday, to ensure we catch delayed-releases like this.

Note that there are also larger delays due to holidays like Thanksgiving:

> Due to the Thanksgiving holiday, we will not be providing database
> updates this Friday, November 26.
>
> We will resume our regular update schedule beginning on Tuesday, November 30.

We should probably relax the threshold in the Ophan build to cope with situations like this.
