### PR TITLE
Updated 2 dependencies that might affect ELK logs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,9 +20,9 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-events" % "3.11.0",
   "net.logstash.logback" % "logstash-logback-encoder" % "7.2",
   "org.slf4j" % "log4j-over-slf4j" % "1.7.36", //  log4j-over-slf4j provides `org.apache.log4j.MDC`, which is dynamically loaded by the Lambda runtime
-  "ch.qos.logback" % "logback-classic" % "1.2.11",
+  "ch.qos.logback" % "logback-classic" % "1.4.5",
 
-  "com.lihaoyi" %% "upickle" % "1.6.0",
+  "com.lihaoyi" %% "upickle" % "2.0.0",
   "com.google.guava" % "guava" % "31.1-jre",
   "org.apache.commons" % "commons-compress" % "1.21",
   "commons-io" % "commons-io" % "2.11.0",


### PR DESCRIPTION
## What does this change?

This PR is the outcome of a pairing session with @rtyley to know more about GeoIP DB Refresher before migrating to [GUCDK](https://github.com/guardian/ophan-geoip-db-refresher/pull/234). When we triggered the Lambda manually in AWS we didn't find any logs in ELK. We get the expected logs when we are running locally but not in ELK logs that is why the first thing we thought about is dependencies! 

We are comparing dependencies between one of our repos that works with Lambda and gets logs, [Ophan Google Search Index Checker](https://github.com/guardian/ophan-google-search-index-checker/blob/117fe85768cdd37b481cb0a9504469fe3f9753cb/build.sbt#L20-L25), and GeoIP DB Resfresher. 

We have found different versions for 2 dependencies and that is the first direction we are going to take.

## How to test

To be added!

## How can we measure success?

We have logs in ELK when we trigger Lambda manually. 

## Have we considered potential risks?

To be added!
