### PR TITLE
Fixes the riff-raff cfn deploy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ assemblyJarName := s"${name.value}.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
-riffRaffArtifactResources += (file("cfn.json"), "cdk/cdk.out/GeoipDbRefresher-PROD.template.json")
+riffRaffArtifactResources += (file("cdk/cdk.out/GeoipDbRefresher-PROD.template.json"), "cloudformation/cfn.json")
 
 assembly / assemblyMergeStrategy := {
   case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard


### PR DESCRIPTION
## What does this change?

This is a small PR that adds the correct location of `cfn.json` in AWS S3 riff-raff artifact and that is used for riff-raff deployments which is part of this #234 

## How to test

We manually deployed this branch in riff-raff and the deployment was successful. 

## How can we measure success?

riff-raff will be able to find the `cfn.json` so we could have successful deployments.

## Have we considered potential risks?

None for this change.
