### PR TITLE
bump commons-compress

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ libraryDependencies ++= Seq(
 
   "com.lihaoyi" %% "upickle" % "3.1.4",
   "com.google.guava" % "guava" % "32.1.3-jre",
-  "org.apache.commons" % "commons-compress" % "1.24.0",
+  "org.apache.commons" % "commons-compress" % "1.26.0",
   "commons-io" % "commons-io" % "2.15.1",
 
 ) ++ Seq("ssm", "s3", "url-connection-client").map(artifact => "software.amazon.awssdk" % artifact % "2.25.28")

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ libraryDependencies ++= Seq(
 
   "com.lihaoyi" %% "upickle" % "3.1.4",
   "com.google.guava" % "guava" % "32.1.3-jre",
-  "org.apache.commons" % "commons-compress" % "1.26.0",
+  "org.apache.commons" % "commons-compress" % "1.26.2",
   "commons-io" % "commons-io" % "2.15.1",
 
 ) ++ Seq("ssm", "s3", "url-connection-client").map(artifact => "software.amazon.awssdk" % artifact % "2.25.28")

--- a/src/main/scala/ophan/geoip/db/refresher/ArchiveInputStreamIterator.scala
+++ b/src/main/scala/ophan/geoip/db/refresher/ArchiveInputStreamIterator.scala
@@ -5,15 +5,14 @@ import org.apache.commons.io.input.CloseShieldInputStream
 
 import java.io.InputStream
 
-class ArchiveInputStreamIterator(archiveInputStream: ArchiveInputStream) extends Iterator[(ArchiveEntry, InputStream)] {
-  private var latest: ArchiveEntry = _
+class ArchiveInputStreamIterator[E <: ArchiveEntry](archiveInputStream: ArchiveInputStream[E]) extends Iterator[(E, InputStream)] {
+  private var latest: E = _
 
   override def hasNext: Boolean = {
     latest = archiveInputStream.getNextEntry
-
     latest != null
   }
 
-  override def next(): (ArchiveEntry, InputStream) =
+  override def next(): (E, InputStream) =
     (latest, CloseShieldInputStream.wrap(archiveInputStream))
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## Why?

There is a medium and high vulnerability introduced through version 1.24 of the `commons-compress` library. Info here: https://app.snyk.io/org/guardian-ophan/project/ae7fc74c-6139-4f71-a173-072735846bfb

Can fix by upgrading to 1.26.

https://metrics.gutools.co.uk/d/fdib3p8l85jwgd/dependency-vulnerabilities-by-team?orgId=1&var-repo_owner=ophan
## What does this change?

Updates the `org.apache.commons:commons-compress` library from version `1.24.0` to `1.26.2`. The upgrade required modifications to handle the new generic type parameter introduced in `ArchiveInputStream`.

#### Details

**Old Definition:**
```java
public abstract class ArchiveInputStream extends InputStream {}
```

**New Definition:**
```java
public abstract class ArchiveInputStream<E extends ArchiveEntry> extends FilterInputStream {}
```

### Changes Made

1. **Update `ArchiveInputStreamIterator` Class:**
   - Changed `ArchiveInputStreamIterator` to handle the generic type parameter `<E extends ArchiveEntry>`.
   - Updated `latest` to be of type `E`.

2. **Update `MaxmindDatabaseEdition` Class:**
   - Updated the usage of `ArchiveInputStream` to specify the type parameter `ArchiveEntry`.

3. **Implicit `Using.Releasable` Instance:**
   - Added an implicit `Using.Releasable` instance for `ArchiveInputStream`. There was an error without this. I think this is because with the introduction of generics, Scala can no longer infer the correct way to release a generic `ArchiveInputStream` without explicit guidance.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
