### PR TITLE
Bump netty handler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,8 @@ libraryDependencies ++= Seq(
 
 ) ++ Seq("ssm", "s3", "url-connection-client").map(artifact => "software.amazon.awssdk" % artifact % "2.25.28")
 
+dependencyOverrides += "io.netty" % "netty-handler" % "4.1.118.Final"
+
 enablePlugins(BuildInfoPlugin)
 
 assembly / assemblyOutputPath  := file(s"target/${name.value}.jar")


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Forces an override of the netty handler version in order to fix this dependabot alert https://github.com/guardian/ophan-geoip-db-refresher/security/dependabot/31

## How to test
Run the geoip refresher locally and ensure nothing breaks