### PR TITLE
Bump netty version, and remove dependencyOverride

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,10 +24,8 @@ libraryDependencies ++= Seq(
   "com.google.guava" % "guava" % "32.1.3-jre",
   "org.apache.commons" % "commons-compress" % "1.26.2",
   "commons-io" % "commons-io" % "2.15.1",
-
+  "io.netty" % "netty-handler" % "4.1.124.Final"
 ) ++ Seq("ssm", "s3", "url-connection-client").map(artifact => "software.amazon.awssdk" % artifact % "2.25.28")
-
-dependencyOverrides += "io.netty" % "netty-handler" % "4.1.118.Final"
 
 enablePlugins(BuildInfoPlugin)
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Bumps the version of netty-handler to the latest, and removes the dependency override.  SBT will use only the latest version of any sub-dependency, and the override will stop this happening. This PR sets netty-handler as a standard dependency for this reason.

Should resolve https://github.com/guardian/ophan-geoip-db-refresher/security/dependabot/38